### PR TITLE
Fix license typo

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -118,7 +118,7 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
         ['hasRecord'] = false,
         ['date'] = nil
     }
-    PlayerData.metadata['licences'] = PlayerData.metadata['licences'] or {
+    PlayerData.metadata['licenses'] = PlayerData.metadata['licenses'] or {
         ['driver'] = true,
         ['business'] = false,
         ['weapon'] = false


### PR DESCRIPTION
## Description

Fixes license typo, if spelled correctly in another resource it would cause an issue, in such cases weapon license and qb-shops

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x ] My code fits the style guidelines.
- [x ] My PR fits the contribution guidelines.
