### PR TITLE
Fixed health resetting after restart

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -87,6 +87,7 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     PlayerData.charinfo.account = PlayerData.charinfo.account or QBCore.Functions.CreateAccountNumber()
     -- Metadata
     PlayerData.metadata = PlayerData.metadata or {}
+    PlayerData.metadata['health'] = PlayerData.metadata['health'] or 200
     PlayerData.metadata['hunger'] = PlayerData.metadata['hunger'] or 100
     PlayerData.metadata['thirst'] = PlayerData.metadata['thirst'] or 100
     PlayerData.metadata['stress'] = PlayerData.metadata['stress'] or 0


### PR DESCRIPTION
**fixed health not saving after restart**
This is an old fix for a server that I made when I was working on it. The fix itself is quite simple it just saves players health metadata and when the player loads into the server he has the same health just like he left after the restart. This also fixes female peds not having the same health ratio as male peds

**Important**
for this pr to work you also need to accept my qb-ambulancejob pr because it adds the correct health value and not the max value when loaded
