### PR TITLE
QB notify to ox_lib

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -168,8 +168,8 @@ RegisterNetEvent('QBCore:Player:UpdatePlayerData', function()
     TriggerServerEvent('QBCore:UpdatePlayer')
 end)
 
-RegisterNetEvent('QBCore:Notify', function(text, type, length)
-    QBCore.Functions.Notify(text, type, length)
+RegisterNetEvent('QBCore:Notify', function(text, notifytype, length)
+    QBCore.Functions.Notify(text, notifytype, length)
 end)
 
 -- This event is exploitable and should not be used. It has been deprecated, and will be removed soon.

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -85,29 +85,35 @@ RegisterNUICallback('getNotifyConfig', function(_, cb)
     cb(QBCore.Config.Notify)
 end)
 
-function QBCore.Functions.Notify(text, texttype, length)
-    if type(text) == "table" then
-        local ttext = text.text or 'Placeholder'
-        local caption = text.caption or 'Placeholder'
-        texttype = texttype or 'primary'
-        length = length or 5000
-        SendNUIMessage({
-            action = 'notify',
-            type = texttype,
-            length = length,
-            text = ttext,
-            caption = caption
-        })
-    else
-        texttype = texttype or 'primary'
-        length = length or 5000
-        SendNUIMessage({
-            action = 'notify',
-            type = texttype,
-            length = length,
-            text = text
-        })
+function QBCore.Functions.Notify(text, notifytype, length)
+    local texttype = (notifytype == 'primary' and 'inform') or notifytype or 'inform'
+    local duration = length or 5000
+    local title = text
+    local description = nil
+    local style = {}
+    local icon
+    local iconColor
+    if texttype == 'police' or texttype == 'ambulance' then
+        style = texttype == 'police' and { backgroundColor = '#141517', color = '#ffffff' } or { backgroundColor = '#141517', color = '#ffffff' }
+        icon = texttype == 'police' and 'tower-broadcast' or 'circle-exclamation'
+        iconColor = texttype == 'police' and '#d60d17' or '#C0392B'
     end
+
+    if type(text) == "table" then
+        title = text.text or 'Placeholder'
+        description = text.caption or 'Placeholder'
+    end
+
+    lib.notify({
+        title = title,
+        description = description,
+        type = texttype,
+        position = QBConfig.Notify.NotificationStyling.position,
+        duration = duration,
+        style = style or nil,
+        icon = icon or nil,
+        iconColor = iconColor or nil
+    })
 end
 
 function QBCore.Debug(resource, obj, depth)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -15,7 +15,8 @@ shared_scripts {
     'shared/vehicles.lua',
     'shared/gangs.lua',
     'shared/weapons.lua',
-    'shared/locations.lua'
+    'shared/locations.lua',
+    '@ox_lib/init.lua'
 }
 
 client_scripts {

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -413,6 +413,6 @@ function QBCore.Functions.HasItem(source, items, amount)
     return exports['qb-inventory']:HasItem(source, items, amount)
 end
 
-function QBCore.Functions.Notify(source, text, type, length)
-    TriggerClientEvent('QBCore:Notify', source, text, type, length)
+function QBCore.Functions.Notify(source, text, notifytype, length)
+    TriggerClientEvent('QBCore:Notify', source, text, notifytype, length)
 end


### PR DESCRIPTION
## Description
Changes the notify function to ox_lib, backwards compatible including police and ambulance notification type
Tried to make a **"better"** (very big quotes) version of #10 
Since the NotifyV2 is literally the oxlib function keeping only the QB function for backwards compatibility (but we can still use it i guess) makes more sense
## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
