### PR TITLE
feat(server): check duplicate licenses on player joining

### DIFF
--- a/server/events.lua
+++ b/server/events.lua
@@ -15,7 +15,7 @@ AddEventHandler('playerJoining', function()
     local license = QBCore.Functions.GetIdentifier(src, 'license')
     if not license then return end
     if usedLicenses[license] then
-        Wait(0)
+        Wait(0) -- mandatory wait for the drop reason to show up
         DropPlayer(src, Lang:t('error.duplicate_license'))
     else
         usedLicenses[license] = true

--- a/server/events.lua
+++ b/server/events.lua
@@ -1,5 +1,7 @@
 -- Event Handler
 
+local usedLicenses = {}
+
 AddEventHandler('chatMessage', function(_, _, message)
     if string.sub(message, 1, 1) == '/' then
         CancelEvent()
@@ -7,8 +9,23 @@ AddEventHandler('chatMessage', function(_, _, message)
     end
 end)
 
+AddEventHandler('playerJoining', function()
+    if not QBConfig.Server.CheckDuplicateLicense then return end
+    local src = source
+    local license = QBCore.Functions.GetIdentifier(src, 'license')
+    if not license then return end
+    if usedLicenses[license] then
+        Wait(0)
+        DropPlayer(src, Lang:t('error.duplicate_license'))
+    else
+        usedLicenses[license] = true
+    end
+end)
+
 AddEventHandler('playerDropped', function(reason)
     local src = source
+    local license = QBCore.Functions.GetIdentifier(src, 'license')
+    if license then usedLicenses[license] = nil end
     if not QBCore.Players[src] then return end
     local Player = QBCore.Players[src]
     TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Dropped', 'red', '**' .. GetPlayerName(src) .. '** (' .. Player.PlayerData.license .. ') left..' ..'\n **Reason:** ' .. reason)


### PR DESCRIPTION
## Description

Needs feedback & testing, maybe it doesn't work and/or maybe there's a better solution.

Fixes QBCore issue qbcore-framework/qb-core#823

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
