### PR TITLE
Handle isLoggedIn on the server instead of the client

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -1,9 +1,6 @@
 -- Player load and unload handling
--- New method for checking if logged in across all scripts (optional)
--- if LocalPlayer.state.isLoggedIn then
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     ShutdownLoadingScreenNui()
-    LocalPlayer.state:set('isLoggedIn', true, false)
     IsLoggedIn = true
     if not QBConfig.Server.PVP then return end
     SetCanAttackFriendly(PlayerPedId(), true, false)
@@ -11,7 +8,6 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
 end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
-    LocalPlayer.state:set('isLoggedIn', false, false)
     IsLoggedIn = false
 end)
 

--- a/server/events.lua
+++ b/server/events.lua
@@ -99,6 +99,17 @@ end
 
 AddEventHandler('playerConnecting', onPlayerConnecting)
 
+-- New method for checking if logged in across all scripts (optional)
+-- `if LocalPlayer.state.isLoggedIn then` for the client side
+-- `if Player(source).state.isLoggedIn then` for the server side
+RegisterNetEvent('QBCore:Server:OnPlayerLoaded', function()
+    Player(source).state:set('isLoggedIn', true, true)
+end)
+
+AddEventHandler('QBCore:Server:OnPlayerUnload', function(source)
+    Player(source).state:set('isLoggedIn', false, true)
+end)
+
 -- Open & Close Server (prevents players from joining)
 
 RegisterNetEvent('QBCore:Server:CloseServer', function(reason)


### PR DESCRIPTION
## Description

Now I can check isLoggedIn on the server as well

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
