### PR TITLE
Patch 1

### DIFF
--- a/server/events.lua
+++ b/server/events.lua
@@ -27,7 +27,7 @@ AddEventHandler('playerDropped', function(reason)
     local license = QBCore.Functions.GetIdentifier(src, 'license')
     if license then usedLicenses[license] = nil end
     if not QBCore.Players[src] then return end
-    GlobalState.Players -= 1
+    GlobalState.PlayerCount -= 1
     local Player = QBCore.Players[src]
     TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Dropped', 'red', '**' .. GetPlayerName(src) .. '** (' .. Player.PlayerData.license .. ') left..' ..'\n **Reason:** ' .. reason)
     Player.Functions.Save()

--- a/server/player.lua
+++ b/server/player.lua
@@ -1,5 +1,6 @@
 QBCore.Players = {}
 QBCore.Player = {}
+GlobalState.Players = 0
 
 -- On player login get their data or set defaults
 -- Don't touch any of this unless you know what you are doing
@@ -187,6 +188,7 @@ function QBCore.Player.Logout(source)
 
     Wait(200)
     QBCore.Players[source] = nil
+    GlobalState.Players -= 1
 end
 
 -- Create a new character
@@ -421,6 +423,7 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
         QBCore.Player.Save(self.PlayerData.source)
 
         -- At this point we are safe to emit new instance to third party resource for load handling
+        GlobalState.Players += 1
         TriggerEvent('QBCore:Server:PlayerLoaded', self)
         self.Functions.UpdatePlayerData()
     end

--- a/server/player.lua
+++ b/server/player.lua
@@ -1,6 +1,6 @@
 QBCore.Players = {}
 QBCore.Player = {}
-GlobalState.Players = 0
+GlobalState.PlayerCount = 0
 
 -- On player login get their data or set defaults
 -- Don't touch any of this unless you know what you are doing
@@ -188,7 +188,7 @@ function QBCore.Player.Logout(source)
 
     Wait(200)
     QBCore.Players[source] = nil
-    GlobalState.Players -= 1
+    GlobalState.PlayerCount -= 1
 end
 
 -- Create a new character
@@ -423,7 +423,7 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
         QBCore.Player.Save(self.PlayerData.source)
 
         -- At this point we are safe to emit new instance to third party resource for load handling
-        GlobalState.Players += 1
+        GlobalState.PlayerCount += 1
         TriggerEvent('QBCore:Server:PlayerLoaded', self)
         self.Functions.UpdatePlayerData()
     end


### PR DESCRIPTION
Pretty self explanatory.

A big issue with QBCore is that there's no such thing that gets a playercount and the resources who needs it (Small resources and Scoreboard) uses a server sided loop through ALL players and then says thats the player count which is EXTREMELY bad for optimizations.