### PR TITLE
refactor(client): HasItem: use ox_inventory export

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -12,6 +12,14 @@ function QBCore.Functions.GetCoords(entity)
     return vector4(coords.x, coords.y, coords.z, GetEntityHeading(entity))
 end
 
+--- QBCore.Functions.HasItem checks if a player has the specified `items` in their inventory
+--- with the specified `amount`.
+---
+--- @param items    The item(s) to check for. Can be a string or a table.
+--- @param amount   The desired quantity of each item
+---
+--- @return boolean Returns true if the player has the specified items in the desired quantity,
+---                 false otherwise
 function QBCore.Functions.HasItem(items, amount)
     local count = exports.ox_inventory:Search('count', items)
 

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -13,7 +13,18 @@ function QBCore.Functions.GetCoords(entity)
 end
 
 function QBCore.Functions.HasItem(items, amount)
-    return exports['qb-inventory']:HasItem(items, amount)
+    local count = exports.ox_inventory:Search('count', items)
+
+    if type(items) == 'table' and type(count) == 'table' then
+        for _, v in pairs(count) do
+            if v < amount then
+                return false
+            end
+        end
+        return true
+    end
+     
+    return count >= amount
 end
 
 -- Utility

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -13,7 +13,8 @@ function QBCore.Functions.GetCoords(entity)
 end
 
 --- QBCore.Functions.HasItem checks if a player has the specified `items` in their inventory
---- with the specified `amount`.
+--- with the specified `amount`. Returns true if the player has at least the amount specified
+--- and not that the player has the exact amount.
 ---
 --- @param items string|string[]    The item(s) to check for. Can be a string or a table and is mandatory.
 --- @param amount? integer          The desired quantity of each item. Acceptable to pass nil, will default to 1.

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -15,14 +15,14 @@ end
 --- QBCore.Functions.HasItem checks if a player has the specified `items` in their inventory
 --- with the specified `amount`.
 ---
---- @param items string|string[]    The item(s) to check for. Can be a string or a table.
---- @param amount integer           The desired quantity of each item.
+--- @param items string|string[]    The item(s) to check for. Can be a string or a table and is mandatory.
+--- @param amount? integer          The desired quantity of each item. Acceptable to pass nil, will default to 1.
 ---
 --- @return boolean Returns true if the player has the specified items in the desired quantity,
 ---                 false otherwise
 function QBCore.Functions.HasItem(items, amount)
+    amount = amount or 1
     local count = exports.ox_inventory:Search('count', items)
-
     if type(items) == 'table' and type(count) == 'table' then
         for _, v in pairs(count) do
             if v < amount then
@@ -31,7 +31,6 @@ function QBCore.Functions.HasItem(items, amount)
         end
         return true
     end
-     
     return count >= amount
 end
 

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -15,8 +15,8 @@ end
 --- QBCore.Functions.HasItem checks if a player has the specified `items` in their inventory
 --- with the specified `amount`.
 ---
---- @param items    The item(s) to check for. Can be a string or a table.
---- @param amount   The desired quantity of each item
+--- @param items string|string[]    The item(s) to check for. Can be a string or a table.
+--- @param amount integer           The desired quantity of each item.
 ---
 --- @return boolean Returns true if the player has the specified items in the desired quantity,
 ---                 false otherwise

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -14,7 +14,8 @@ end
 
 --- QBCore.Functions.HasItem checks if a player has the specified `items` in their inventory
 --- with the specified `amount`. Returns true if the player has at least the amount specified
---- and not that the player has the exact amount.
+--- and not that the player has the exact amount. If the user passes nil for `amount` then we 
+--- default to 1 - as it's self explainatory within the functions name.
 ---
 --- @param items string|string[]    The item(s) to check for. Can be a string or a table and is mandatory.
 --- @param amount? integer          The desired quantity of each item. Acceptable to pass nil, will default to 1.


### PR DESCRIPTION
QBCore.Functions.HasItems just returned back a boolean from qb-inventory. ox_inventory has something very similar, but does not return back a boolean - it returns back a table with k/v pairs with the item and the count that the player has.

This refactor calls the ox_inventory export, and does the logic to determine whether or not it's a table or a single string to check against. This allows you to:

1. Specify a string: `QBCore.Functions.HasItem('drill', 1)`
2. Specify a table with 1 item: `QBCore.Functions.HasItem({'drill'}, 1)`
3. Specify a table with many items: `QBCore.Functions.HasItem({'drill', 'water_bottle'}, 1)`

This allows us to maintain existing functionality for escrowed scripts that use this function.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
