### PR TITLE
Use statebags for me command

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -209,14 +209,25 @@ local function Draw3DText(coords, str)
     end
 end
 
-RegisterNetEvent('QBCore:Command:ShowMe3D', function(senderId, msg)
-    local sender = GetPlayerFromServerId(senderId)
+AddStateBagChangeHandler('me', nil, function(bagName, _, value)
+    if not value then return end
+
+    local playerId = GetPlayerFromStateBagName(bagName)
+
+    if not playerId then return end
+
+    local playerPed = GetPlayerPed(playerId)
+
+    -- Here we do a entity check to see if the player exsist within each clients scope --
+    if not DoesEntityExist(playerPed) then return end
+
+    -- Distance check to make sure that players do not see others me from 100s of meters away --
+    if #(GetEntityCoords(playerPed) - GetEntityCoords(cache.ped)) > 25 then return end
+
     CreateThread(function()
         local displayTime = 5000 + GetGameTimer()
         while displayTime > GetGameTimer() do
-            local targetPed = GetPlayerPed(sender)
-            local tCoords = GetEntityCoords(targetPed)
-            Draw3DText(tCoords, msg)
+            Draw3DText(GetEntityCoords(playerPed), value)
             Wait(0)
         end
     end)

--- a/client/events.lua
+++ b/client/events.lua
@@ -214,7 +214,7 @@ AddStateBagChangeHandler('me', nil, function(bagName, _, value)
 
     local playerId = GetPlayerFromStateBagName(bagName)
 
-    if not playerId then return end
+    if not playerId or not NetworkIsPlayerActive(playerId) then return end
 
     local isLocalPlayer = playerId == cache.playerId
     local playerPed = isLocalPlayer and cache.ped or GetPlayerPed(playerId)

--- a/client/events.lua
+++ b/client/events.lua
@@ -216,17 +216,19 @@ AddStateBagChangeHandler('me', nil, function(bagName, _, value)
 
     if not playerId then return end
 
-    local playerPed = GetPlayerPed(playerId)
+    local isLocalPlayer = playerId == cache.playerId
+    local playerPed = isLocalPlayer and cache.ped or GetPlayerPed(playerId)
 
     -- Here we do a entity check to see if the player exsist within each clients scope --
     if not DoesEntityExist(playerPed) then return end
 
     -- Distance check to make sure that players do not see others me from 100s of meters away --
-    if #(GetEntityCoords(playerPed) - GetEntityCoords(cache.ped)) > 25 then return end
+    if not isLocalPlayer and #(GetEntityCoords(playerPed) - GetEntityCoords(cache.ped)) > 25 then return end
 
     CreateThread(function()
         local displayTime = 5000 + GetGameTimer()
         while displayTime > GetGameTimer() do
+            playerPed = isLocalPlayer and cache.ped or GetPlayerPed(playerId)
             Draw3DText(GetEntityCoords(playerPed), value)
             Wait(0)
         end

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -278,18 +278,13 @@ end, 'user')
 
 -- Me command
 
-QBCore.Commands.Add('me', Lang:t("command.me.help"), {{name = Lang:t("command.me.params.message.name"), help = Lang:t("command.me.params.message.help")}}, false, function(source, args)
+QBCore.Commands.Add('me', Lang:t("comm.me"), {{name = Lang:t("comm.me_m"), help = Lang:t("comm.me_mh")}}, false, function(source, args)
     if #args < 1 then TriggerClientEvent('QBCore:Notify', source, Lang:t('error.missing_args2'), 'error') return end
-    local ped = GetPlayerPed(source)
-    local pCoords = GetEntityCoords(ped)
     local msg = table.concat(args, ' '):gsub('[~<].-[>~]', '')
-    local Players = QBCore.Functions.GetPlayers()
-    for i=1, #Players do
-        local Player = Players[i]
-        local target = GetPlayerPed(Player)
-        local tCoords = GetEntityCoords(target)
-        if target == ped or #(pCoords - tCoords) < 20 then
-            TriggerClientEvent('QBCore:Command:ShowMe3D', Player, source, msg)
-        end
-    end
+    local playerState = Player(source).state
+    playerState:set('me', msg, true)
+
+    -- We have to reset the playerState since the state does not get replicated on StateBagHandler if the value is the same as the previous one --
+    playerState:set('me', nil, true)
 end, 'user')
+

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -278,7 +278,7 @@ end, 'user')
 
 -- Me command
 
-QBCore.Commands.Add('me', Lang:t("comm.me"), {{name = Lang:t("comm.me_m"), help = Lang:t("comm.me_mh")}}, false, function(source, args)
+QBCore.Commands.Add('me', Lang:t("command.me.help"), {{name = Lang:t("command.me.params.message.name"), help = Lang:t("command.me.params.message.help")}}, false, function(source, args)
     if #args < 1 then TriggerClientEvent('QBCore:Notify', source, Lang:t('error.missing_args2'), 'error') return end
     local msg = table.concat(args, ' '):gsub('[~<].-[>~]', '')
     local playerState = Player(source).state


### PR DESCRIPTION
## Description

Optimized the me command that is used frequently in servers, this change gets rid of stupid server side distance checks and uses statebags.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
