### PR TITLE
feat(server)!: add storage layer

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -17,42 +17,39 @@ QBConfig.Player.ThirstRate = 3.8 -- Rate at which thirst goes down.
 QBConfig.Player.Bloodtypes = {
     "A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-",
 }
+
+---@alias UniqueIdType 'citizenid' | 'AccountNumber' | 'PhoneNumber' | 'FingerId' | 'WalletId' | 'SerialNumber'
+---@type table<UniqueIdType, {valueFunction: function}>
 QBConfig.Player.IdentifierTypes = {
     ['citizenid'] = {
-        ValueFunction = function()
+        valueFunction = function()
             return tostring(QBCore.Shared.RandomStr(3) .. QBCore.Shared.RandomInt(5)):upper()
         end,
-        DatabaseColumn = 'citizenid'
     },
     ['AccountNumber'] = {
-        ValueFunction = function()
+        valueFunction = function()
             return 'US0' .. math.random(1, 9) .. 'QBCore' .. math.random(1111, 9999) .. math.random(1111, 9999) .. math.random(11, 99)
         end,
-        DatabaseColumn = 'charinfo'
     },
     ['PhoneNumber'] = {
-        ValueFunction = function()
+        valueFunction = function()
             return math.random(100,999) .. math.random(1000000,9999999)
         end,
-        DatabaseColumn = 'charinfo'
     },
     ['FingerId'] = {
-        ValueFunction = function()
+        valueFunction = function()
             return tostring(QBCore.Shared.RandomStr(2) .. QBCore.Shared.RandomInt(3) .. QBCore.Shared.RandomStr(1) .. QBCore.Shared.RandomInt(2) .. QBCore.Shared.RandomStr(3) .. QBCore.Shared.RandomInt(4))
         end,
-        DatabaseColumn = 'metadata'
     },
     ['WalletId'] = {
-        ValueFunction = function()
+        valueFunction = function()
             return 'QB-' .. math.random(11111111, 99999999)
         end,
-        DatabaseColumn = 'metadata'
     },
     ['SerialNumber'] = {
-        ValueFunction = function()
+        valueFunction = function()
             return math.random(11111111, 99999999)
         end,
-        DatabaseColumn = 'metadata'
     },
 }
 

--- a/server/exports.lua
+++ b/server/exports.lua
@@ -320,15 +320,17 @@ exports('GetCoreVersion', GetCoreVersion)
 
 local function ExploitBan(playerId, origin)
     local name = GetPlayerName(playerId)
-    MySQL.insert('INSERT INTO bans (name, license, discord, ip, reason, expire, bannedby) VALUES (?, ?, ?, ?, ?, ?, ?)', {
-        name,
-        QBCore.Functions.GetIdentifier(playerId, 'license'),
-        QBCore.Functions.GetIdentifier(playerId, 'discord'),
-        QBCore.Functions.GetIdentifier(playerId, 'ip'),
-        origin,
-        2147483647,
-        'Anti Cheat'
-    })
+    CreateThread(function()
+        InsertBanEntity({
+            name = name,
+            license = QBCore.Functions.GetIdentifier(playerId, 'license'),
+            discordId = QBCore.Functions.GetIdentifier(playerId, 'discord'),
+            ip = QBCore.Functions.GetIdentifier(playerId, 'ip'),
+            reason = origin,
+            expiration = 2147483647,
+            bannedBy = 'Anti Cheat'
+        })
+    end)
     DropPlayer(playerId, Lang:t('info.exploit_banned', {discord = QBCore.Config.Server.Discord}))
     TriggerEvent("qb-log:server:CreateLog", "anticheat", "Anti-Cheat", "red", name .. " has been banned for exploiting " .. origin, true)
 end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -358,7 +358,7 @@ end
 
 function QBCore.Functions.IsPlayerBanned(source)
     local plicense = QBCore.Functions.GetIdentifier(source, 'license')
-    local result = GetBanEntity({
+    local result = FetchBanEntity({
         license = plicense
     })
     if not result then return false end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -358,13 +358,19 @@ end
 
 function QBCore.Functions.IsPlayerBanned(source)
     local plicense = QBCore.Functions.GetIdentifier(source, 'license')
-    local result = MySQL.single.await('SELECT * FROM bans WHERE license = ?', { plicense })
+    local result = GetBanEntity({
+        license = plicense
+    })
     if not result then return false end
     if os.time() < result.expire then
         local timeTable = os.date('*t', tonumber(result.expire))
         return true, 'You have been banned from the server:\n' .. result.reason .. '\nYour ban expires ' .. timeTable.day .. '/' .. timeTable.month .. '/' .. timeTable.year .. ' ' .. timeTable.hour .. ':' .. timeTable.min .. '\n'
     else
-        MySQL.query('DELETE FROM bans WHERE id = ?', { result.id })
+        CreateThread(function()
+            DeleteBanEntity({
+                license = plicense
+            })
+        end)
     end
     return false
 end

--- a/server/player.lua
+++ b/server/player.lua
@@ -10,7 +10,7 @@ function QBCore.Player.Login(source, citizenid, newData)
     if source and source ~= '' then
         if citizenid then
             local license, license2 = QBCore.Functions.GetIdentifier(source, 'license'), QBCore.Functions.GetIdentifier(source, 'license2')
-            local PlayerData = GetPlayerEntity(citizenid)
+            local PlayerData = FetchPlayerEntity(citizenid)
             if PlayerData and license == PlayerData.license or PlayerData and license2 == PlayerData.license then
                 QBCore.Player.CheckPlayerData(source, PlayerData)
             else
@@ -29,7 +29,7 @@ end
 
 function QBCore.Player.GetOfflinePlayer(citizenid)
     if citizenid then
-        local PlayerData = GetPlayerEntity(citizenid)
+        local PlayerData = FetchPlayerEntity(citizenid)
         if PlayerData then
             return QBCore.Player.CheckPlayerData(nil, PlayerData)
         end
@@ -503,7 +503,7 @@ end
 
 function QBCore.Player.DeleteCharacter(source, citizenid)
     local license, license2 = QBCore.Functions.GetIdentifier(source, 'license'), QBCore.Functions.GetIdentifier(source, 'license2')
-    local result = GetPlayerEntity(citizenid).license
+    local result = FetchPlayerEntity(citizenid).license
     if license == result or license2 == result then
         CreateThread(function()
             local success = DeletePlayerEntity(citizenid)
@@ -518,7 +518,7 @@ function QBCore.Player.DeleteCharacter(source, citizenid)
 end
 
 function QBCore.Player.ForceDeleteCharacter(citizenid)
-    local result = GetPlayerEntity(citizenid).license
+    local result = FetchPlayerEntity(citizenid).license
     if result then
         local Player = QBCore.Functions.GetPlayerByCitizenId(citizenid)
         if Player then
@@ -569,7 +569,7 @@ function QBCore.Player.GenerateUniqueIdentifier(type)
     local table = QBConfig.Player.IdentifierTypes[type]
     repeat
         uniqueId = table.valueFunction()
-        isUnique = IsUnique(type, uniqueId)
+        isUnique = FetchIsUnique(type, uniqueId)
     until isUnique
     return uniqueId
 end

--- a/server/player.lua
+++ b/server/player.lua
@@ -501,21 +501,6 @@ end
 
 -- Delete character
 
-local playertables = { -- Add tables as needed
-    { table = 'players' },
-    { table = 'apartments' },
-    { table = 'bank_accounts' },
-    { table = 'crypto_transactions' },
-    { table = 'phone_invoices' },
-    { table = 'phone_messages' },
-    { table = 'playerskins' },
-    { table = 'player_contacts' },
-    { table = 'player_houses' },
-    { table = 'player_mails' },
-    { table = 'player_outfits' },
-    { table = 'player_vehicles' }
-}
-
 function QBCore.Player.DeleteCharacter(source, citizenid)
     local license, license2 = QBCore.Functions.GetIdentifier(source, 'license'), QBCore.Functions.GetIdentifier(source, 'license2')
     local result = GetPlayerEntity(citizenid).license

--- a/server/player.lua
+++ b/server/player.lua
@@ -10,18 +10,8 @@ function QBCore.Player.Login(source, citizenid, newData)
     if source and source ~= '' then
         if citizenid then
             local license, license2 = QBCore.Functions.GetIdentifier(source, 'license'), QBCore.Functions.GetIdentifier(source, 'license2')
-            local PlayerData = MySQL.prepare.await('SELECT * FROM players where citizenid = ?', { citizenid })
+            local PlayerData = GetPlayerEntity(citizenid)
             if PlayerData and license == PlayerData.license or PlayerData and license2 == PlayerData.license then
-                PlayerData.money = json.decode(PlayerData.money)
-                PlayerData.job = json.decode(PlayerData.job)
-                PlayerData.position = json.decode(PlayerData.position)
-                PlayerData.metadata = json.decode(PlayerData.metadata)
-                PlayerData.charinfo = json.decode(PlayerData.charinfo)
-                if PlayerData.gang then
-                    PlayerData.gang = json.decode(PlayerData.gang)
-                else
-                    PlayerData.gang = {}
-                end
                 QBCore.Player.CheckPlayerData(source, PlayerData)
             else
                 DropPlayer(source, Lang:t("info.exploit_dropped"))
@@ -39,19 +29,8 @@ end
 
 function QBCore.Player.GetOfflinePlayer(citizenid)
     if citizenid then
-        local PlayerData = MySQL.Sync.prepare('SELECT * FROM players where citizenid = ?', {citizenid})
+        local PlayerData = GetPlayerEntity(citizenid)
         if PlayerData then
-            PlayerData.money = json.decode(PlayerData.money)
-            PlayerData.job = json.decode(PlayerData.job)
-            PlayerData.position = json.decode(PlayerData.position)
-            PlayerData.metadata = json.decode(PlayerData.metadata)
-            PlayerData.charinfo = json.decode(PlayerData.charinfo)
-            if PlayerData.gang then
-                PlayerData.gang = json.decode(PlayerData.gang)
-            else
-                PlayerData.gang = {}
-            end
-
             return QBCore.Player.CheckPlayerData(nil, PlayerData)
         end
     end
@@ -492,17 +471,12 @@ function QBCore.Player.Save(source)
     local pcoords = GetEntityCoords(ped)
     local PlayerData = QBCore.Players[source].PlayerData
     if PlayerData then
-        MySQL.insert('INSERT INTO players (citizenid, license, name, money, charinfo, job, gang, position, metadata) VALUES (:citizenid, :license, :name, :money, :charinfo, :job, :gang, :position, :metadata) ON DUPLICATE KEY UPDATE name = :name, money = :money, charinfo = :charinfo, job = :job, gang = :gang, position = :position, metadata = :metadata', {
-            citizenid = PlayerData.citizenid,
-            license = PlayerData.license,
-            name = PlayerData.name,
-            money = json.encode(PlayerData.money),
-            charinfo = json.encode(PlayerData.charinfo),
-            job = json.encode(PlayerData.job),
-            gang = json.encode(PlayerData.gang),
-            position = json.encode(pcoords),
-            metadata = json.encode(PlayerData.metadata)
-        })
+        CreateThread(function()
+            UpsertPlayerEntity({
+                playerData = PlayerData,
+                position = pcoords,
+            })
+        end)
         if GetResourceState('qb-inventory') ~= 'missing' then exports['qb-inventory']:SaveInventory(source) end
         QBCore.ShowSuccess(GetCurrentResourceName(), PlayerData.name .. ' PLAYER SAVED!')
     else
@@ -512,17 +486,12 @@ end
 
 function QBCore.Player.SaveOffline(PlayerData)
     if PlayerData then
-        MySQL.Async.insert('INSERT INTO players (citizenid, license, name, money, charinfo, job, gang, position, metadata) VALUES (:citizenid, :license, :name, :money, :charinfo, :job, :gang, :position, :metadata) ON DUPLICATE KEY UPDATE name = :name, money = :money, charinfo = :charinfo, job = :job, gang = :gang, position = :position, metadata = :metadata', {
-            citizenid = PlayerData.citizenid,
-            license = PlayerData.license,
-            name = PlayerData.name,
-            money = json.encode(PlayerData.money),
-            charinfo = json.encode(PlayerData.charinfo),
-            job = json.encode(PlayerData.job),
-            gang = json.encode(PlayerData.gang),
-            position = json.encode(PlayerData.position),
-            metadata = json.encode(PlayerData.metadata)
-        })
+        CreateThread(function()
+            UpsertPlayerEntity({
+                playerData = PlayerData,
+                position = PlayerData.position
+            })
+        end)
         if GetResourceState('qb-inventory') ~= 'missing' then exports['qb-inventory']:SaveInventory(PlayerData, true) end
         QBCore.ShowSuccess(GetCurrentResourceName(), PlayerData.name .. ' OFFLINE PLAYER SAVED!')
     else
@@ -549,19 +518,11 @@ local playertables = { -- Add tables as needed
 
 function QBCore.Player.DeleteCharacter(source, citizenid)
     local license, license2 = QBCore.Functions.GetIdentifier(source, 'license'), QBCore.Functions.GetIdentifier(source, 'license2')
-    local result = MySQL.scalar.await('SELECT license FROM players where citizenid = ?', { citizenid })
+    local result = GetPlayerEntity(citizenid).license
     if license == result or license2 == result then
-        local query = "DELETE FROM %s WHERE citizenid = ?"
-        local tableCount = #playertables
-        local queries = table.create(tableCount, 0)
-
-        for i = 1, tableCount do
-            local v = playertables[i]
-            queries[i] = {query = query:format(v.table), values = { citizenid }}
-        end
-
-        MySQL.transaction(queries, function(result2)
-            if result2 then
+        CreateThread(function()
+            local success = DeletePlayerEntity(citizenid)
+            if success then
                 TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Character Deleted', 'red', '**' .. GetPlayerName(source) .. '** ' .. license2 .. ' deleted **' .. citizenid .. '**..')
             end
         end)
@@ -572,23 +533,16 @@ function QBCore.Player.DeleteCharacter(source, citizenid)
 end
 
 function QBCore.Player.ForceDeleteCharacter(citizenid)
-    local result = MySQL.scalar.await('SELECT license FROM players where citizenid = ?', { citizenid })
+    local result = GetPlayerEntity(citizenid).license
     if result then
-        local query = "DELETE FROM %s WHERE citizenid = ?"
-        local tableCount = #playertables
-        local queries = table.create(tableCount, 0)
         local Player = QBCore.Functions.GetPlayerByCitizenId(citizenid)
-
         if Player then
             DropPlayer(Player.PlayerData.source, "An admin deleted the character which you are currently using")
         end
-        for i = 1, tableCount do
-            local v = playertables[i]
-            queries[i] = {query = query:format(v.table), values = { citizenid }}
-        end
 
-        MySQL.transaction(queries, function(result2)
-            if result2 then
+        CreateThread(function()
+            local success = DeletePlayerEntity(citizenid)
+            if success then
                 TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Character Force Deleted', 'red', 'Character **' .. citizenid .. '** got deleted')
             end
         end)
@@ -623,19 +577,14 @@ function QBCore.Player.GetFirstSlotByItem(items, itemName)
 end
 
 ---Generate unique values for player identifiers
----@param type string The type of unique value to generate
+---@param type UniqueIdType The type of unique value to generate
 ---@return string | number UniqueVal unique value generated
 function QBCore.Player.GenerateUniqueIdentifier(type)
-    local result, query, UniqueId
+    local isUnique, uniqueId
     local table = QBConfig.Player.IdentifierTypes[type]
     repeat
-        UniqueId = table.ValueFunction()
-        if table.DatabaseColumn ~= 'citizenid' then
-            query = '%' .. UniqueId .. '%'
-            result = MySQL.prepare.await('SELECT COUNT(*) as count FROM players WHERE ' .. table.DatabaseColumn .. ' LIKE ?', { query })
-        else
-            result = MySQL.prepare.await('SELECT COUNT(*) as count FROM players WHERE ' .. table.DatabaseColumn .. ' = ?', { UniqueId })
-        end
-    until result == 0
-    return UniqueId
+        uniqueId = table.valueFunction()
+        isUnique = IsUnique(type, uniqueId)
+    until isUnique
+    return uniqueId
 end

--- a/server/storage.lua
+++ b/server/storage.lua
@@ -1,0 +1,167 @@
+---@class InsertBanRequest
+---@field name string
+---@field license? string
+---@field discordId? string
+---@field ip? string
+---@field reason string
+---@field bannedBy string
+---@field expiration integer epoch second that the ban will expire
+
+---@param request InsertBanRequest
+function InsertBanEntity(request)
+    if not request.discordId and not request.ip and not request.license then
+        error("no identifier provided")
+    end
+
+    MySQL.insert.await('INSERT INTO bans (name, license, discord, ip, reason, expire, bannedby) VALUES (?, ?, ?, ?, ?, ?, ?)', {
+        request.name,
+        request.license,
+        request.discordId,
+        request.ip,
+        request.reason,
+        request.expiration,
+        request.bannedBy,
+    })
+end
+
+---@param request GetBanRequest
+---@return string column in storage
+---@return string value of the id
+local function getBanId(request)
+    if request.license then
+        return "license", request.license
+    elseif request.discordId then
+        return "discord", request.discordId
+    elseif request.ip then
+        return "ip", request.ip
+    else
+        error("no identifier provided", 2)
+    end
+end
+
+---@class GetBanRequest
+---@field license? string
+---@field discordId? string
+---@field ip? string
+
+---@class BanEntity
+---@field expire integer epoch second that the ban will expire
+---@field reason string
+
+---@param request GetBanRequest
+---@return BanEntity
+function GetBanEntity(request)
+    local column, value = getBanId(request)
+    local result = MySQL.single.await('SELECT * FROM bans WHERE ' ..column.. ' = ?', { value })
+    return {
+        expire = result.expire,
+        reason = result.reason,
+    }
+end
+
+---@param request GetBanRequest
+function DeleteBanEntity(request)
+    local column, value = getBanId(request)
+    MySQL.query.await('DELETE FROM bans WHERE ' ..column.. ' = ?', { value })
+end
+
+---@class UpsertPlayerRequest
+---@field playerData PlayerEntity
+---@field position vector3
+
+---@param request UpsertPlayerRequest
+function UpsertPlayerEntity(request)
+    MySQL.insert.await('INSERT INTO players (citizenid, license, name, money, charinfo, job, gang, position, metadata) VALUES (:citizenid, :license, :name, :money, :charinfo, :job, :gang, :position, :metadata) ON DUPLICATE KEY UPDATE name = :name, money = :money, charinfo = :charinfo, job = :job, gang = :gang, position = :position, metadata = :metadata', {
+        citizenid = request.playerData.citizenid,
+        license = request.playerData.license,
+        name = request.playerData.name,
+        money = json.encode(request.playerData.money),
+        charinfo = json.encode(request.playerData.charinfo),
+        job = json.encode(request.playerData.job),
+        gang = json.encode(request.playerData.gang),
+        position = json.encode(request.position),
+        metadata = json.encode(request.playerData.metadata)
+    })
+end
+
+---TODO: define JSON table contracts
+---@class PlayerEntity
+---@field citizenid string
+---@field license string
+---@field name string
+---@field money number
+---@field charinfo table
+---@field job table
+---@field gang table
+---@field position vector4
+---@field metadata table
+
+---@param citizenId string
+---@return PlayerEntity
+function GetPlayerEntity(citizenId)
+    local player = MySQL.prepare.await('SELECT * FROM players where citizenid = ?', { citizenId })
+    return {
+        citizenid = player.citizenid,
+        license = player.license,
+        name = player.name,
+        money = json.decode(player.money),
+        charinfo = json.decode(player.charinfo),
+        job = json.decode(player.job),
+        gang = player.gang and json.decode(player.gang) or {},
+        position = json.decode(player.position),
+        metadata = json.decode(player.metadata)
+    }
+end
+
+---@param citizenId string
+---@return boolean success if operation is successful.
+function DeletePlayerEntity(citizenId)
+    local playerTables = {
+        'players',
+        'apartments',
+        'bank_accounts',
+        'crypto_transactions',
+        'phone_invoices',
+        'phone_messages',
+        'playerskins',
+        'player_contacts',
+        'player_houses',
+        'player_mails',
+        'player_outfits',
+        'player_vehicles',
+    }
+
+    local query = "DELETE FROM %s WHERE citizenid = ?"
+    local queries = {}
+
+    for i = 1, #playerTables do
+        local table = playerTables[i]
+        queries[i] = {
+            query = query:format(table),
+            values = {
+                citizenId,
+            }
+        }
+    end
+
+    local success = MySQL.transaction.await(queries)
+    return success and true or false
+end
+
+---checks the storage for uniqueness of the given value
+---@param type UniqueIdType
+---@param value string|number
+---@return boolean isUnique if the value does not already exist in storage for the given type
+function IsUnique(type, value)
+    local typeToColumn = {
+        citizenid = "citizenid",
+        AccountNumber = "JSON_VALUE(charinfo, '$.account')",
+        PhoneNumber = "JSON_VALUE(charinfo, '$.phone')",
+        FingerId = "JSON_VALUE(metadata, '$.fingerprint')",
+        WalletId = "JSON_VALUE(metadata, '$.walletid')",
+        SerialNumber = "JSON_VALUE(metadata, '$.phonedata.SerialNumber')",
+    }
+
+    local count = MySQL.prepare.await('SELECT COUNT(*) as count FROM players WHERE ' .. typeToColumn[type] .. ' = ?', { value })
+    return count == 0
+end

--- a/server/storage.lua
+++ b/server/storage.lua
@@ -50,7 +50,7 @@ end
 
 ---@param request GetBanRequest
 ---@return BanEntity
-function GetBanEntity(request)
+function FetchBanEntity(request)
     local column, value = getBanId(request)
     local result = MySQL.single.await('SELECT * FROM bans WHERE ' ..column.. ' = ?', { value })
     return {
@@ -98,7 +98,7 @@ end
 
 ---@param citizenId string
 ---@return PlayerEntity
-function GetPlayerEntity(citizenId)
+function FetchPlayerEntity(citizenId)
     local player = MySQL.prepare.await('SELECT * FROM players where citizenid = ?', { citizenId })
     return {
         citizenid = player.citizenid,
@@ -152,7 +152,7 @@ end
 ---@param type UniqueIdType
 ---@param value string|number
 ---@return boolean isUnique if the value does not already exist in storage for the given type
-function IsUnique(type, value)
+function FetchIsUnique(type, value)
     local typeToColumn = {
         citizenid = "citizenid",
         AccountNumber = "JSON_VALUE(charinfo, '$.account')",


### PR DESCRIPTION
## Description
Introduces a storage layer to abstract away the database schema behind a defined storage API. This allows us to change either the API or the schema without making a breaking change to the other. Right now the API is largely 1:1 with the schema, but that will soon change as the schema diverges.

- made all storage functions synchronous. Calling them from threads to maintain async functionality in the code where it existed before.
- Code now assumes that all bans will have at least one of three identifiers: license, discordId, or ip

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
