### PR TITLE
fix(server/storage): make fetch returns optional

### DIFF
--- a/server/storage.lua
+++ b/server/storage.lua
@@ -49,10 +49,11 @@ end
 ---@field reason string
 
 ---@param request GetBanRequest
----@return BanEntity
+---@return BanEntity?
 function FetchBanEntity(request)
     local column, value = getBanId(request)
     local result = MySQL.single.await('SELECT * FROM bans WHERE ' ..column.. ' = ?', { value })
+    if not result then return end
     return {
         expire = result.expire,
         reason = result.reason,
@@ -97,9 +98,10 @@ end
 ---@field metadata table
 
 ---@param citizenId string
----@return PlayerEntity
+---@return PlayerEntity?
 function FetchPlayerEntity(citizenId)
     local player = MySQL.prepare.await('SELECT * FROM players where citizenid = ?', { citizenId })
+    if not player then return end
     return {
         citizenid = player.citizenid,
         license = player.license,


### PR DESCRIPTION
## Description
- Code previously assumed that bans and players existed within the database if they were being queried. Now there are nil checks and the fetch return types are optional to account for this.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
