### PR TITLE
Fix licensekey error

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -42,7 +42,7 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     local Offline = true
     if source then
         PlayerData.source = source
-        PlayerData.license = PlayerData.license or QBCore.Functions.GetIdentifier(source, 'license2')
+        PlayerData.license = PlayerData.license or QBCore.Functions.GetIdentifier(source, 'license') or QBCore.Functions.GetIdentifier(source, 'license2')
         PlayerData.name = GetPlayerName(source)
         Offline = false
     end


### PR DESCRIPTION
## Description

Fixes an issue where it sees new characters with a null license key. PlayerData.license is null by default.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ X] My code fits the style guidelines.
- [ X] My PR fits the contribution guidelines.
